### PR TITLE
フォーム入力画面と確認画面の実装＆ラベルの日本語化

### DIFF
--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -1,0 +1,20 @@
+<div class="container" mt-3 mb-5>
+  <h1 class="text^center mb-5">注文内容の確認</h1>
+
+  <div class="col-md-6 mx-auto mb-5">
+    <p>以下の内容でよろしいでしょうか？</p>
+    <div class="mb-3">
+      <div class="form-label border-start border-primary border-4 ps-1">
+        <%= t('activerecord.attributes.order.name') %>
+      </div>
+      <%= @order.name %>
+    </div>
+  </div>
+
+  <%= form_for @order, url: orders_path do |f| %>
+    <%= f.hidden_field :name %>
+    <div class="d-grid col-md-6 mx-auto">
+      <%= f.button 'OK', class: 'btn btn-lg btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,0 +1,16 @@
+<div class="container" mt-3 mb-5>
+  <h1 class="text^center mb-5">注文フォーム</h1>
+
+  <%= form_for @order, url: confirm_orders_path do |f| %>
+    <div class="col-md-6 mx-auto mb-5">
+      <div class="mb-3">
+        <%= f.label :name, class: 'form-label border-start border-primary border-4 ps-1' %>
+        <%= f.text_field :name, size: 40, placeholder: 'サンプル太郎', class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="d-grid col-md-6 mx-auto">
+      <%= f.button '確認画面へ', class: 'btn btn-lg btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  activerecord:
+    attributes:
+      order:
+        name: お名前


### PR DESCRIPTION
## 概要

1. 登録画面の実装
2. 確認画面の実装

## 実装詳細

- 追加ファイル

app/views/orders/confirm.html.erb
app/views/orders/new.html.erb
config/locales/ja.yml

- 実装画面（ローカル）
<img width="1422" height="542" alt="スクリーンショット 2025-09-17 182722" src="https://github.com/user-attachments/assets/10bf93c0-87ab-4a81-ae41-e4e00731a890" />
<img width="1345" height="574" alt="スクリーンショット 2025-09-17 182758" src="https://github.com/user-attachments/assets/a169eb8e-4c38-46c6-b2dd-30ec380b4899" />
