### PR TITLE
メールアドレス・電話番号・お届け先住所の項目を追加

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,6 +19,11 @@ class OrdersController < ApplicationController
   private
 
   def order_params
-    params.require(:order).permit(:name)
+    params
+      .require(:order)
+      .permit(:name,
+              :email,
+              :telephone,
+              :delivery_address)
   end
 end

--- a/app/views/orders/complete.html.erb
+++ b/app/views/orders/complete.html.erb
@@ -1,5 +1,5 @@
 <div class="container" mt-3 mb-5>
-  <h1 class="text^center mb-5">注文完了</h1>
+  <h1 class="text-center mb-5">注文完了</h1>
 
   <div class="text-center mb-5">
     <p>

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -9,10 +9,34 @@
       </div>
       <%= @order.name %>
     </div>
+
+    <div class="mb-3">
+      <div class="form-label border-start border-primary border-4 ps-1">
+        <%= t('activerecord.attributes.order.email') %>
+      </div>
+      <%= @order.email %>
+    </div>
+
+    <div class="mb-3">
+      <div class="form-label border-start border-primary border-4 ps-1">
+        <%= t('activerecord.attributes.order.telephone') %>
+      </div>
+      <%= @order.telephone %>
+    </div>
+
+    <div class="mb-3">
+      <div class="form-label border-start border-primary border-4 ps-1">
+        <%= t('activerecord.attributes.order.delivery_address') %>
+      </div>
+      <%= @order.delivery_address %>
+    </div>
   </div>
 
   <%= form_for @order, url: orders_path do |f| %>
     <%= f.hidden_field :name %>
+    <%= f.hidden_field :email %>
+    <%= f.hidden_field :telephone %>
+    <%= f.hidden_field :delivery_address %>
     <div class="d-grid col-md-6 mx-auto mb-3">
       <%= f.button 'OK', class: 'btn btn-lg btn-primary' %>
     </div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -9,6 +9,27 @@
       </div>
     </div>
 
+    <div class="col-md-6 mx-auto mb-5">
+      <div class="mb-3">
+        <%= f.label :email, class: 'form-label border-start border-primary border-4 ps-1' %>
+        <%= f.text_field :email, size: 100, placeholder: 'sample@example.com', class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="col-md-6 mx-auto mb-5">
+      <div class="mb-3">
+        <%= f.label :telephone, class: 'form-label border-start border-primary border-4 ps-1' %>
+        <%= f.text_field :telephone, size: 40, placeholder: '0312345678', class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class="col-md-6 mx-auto mb-5">
+      <div class="mb-3">
+        <%= f.label :delivery_address, class: 'form-label border-start border-primary border-4 ps-1' %>
+        <%= f.text_field :delivery_address, size: 40, placeholder: 'お届け先の住所をご入力ください', class: 'form-control' %>
+      </div>
+    </div>
+
     <div class="d-grid col-md-6 mx-auto">
       <%= f.button '確認画面へ', class: 'btn btn-lg btn-primary' %>
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,3 +3,6 @@ ja:
     attributes:
       order:
         name: お名前
+        email: メールアドレス
+        telephone: 電話番号
+        delivery_address: お届け先住所

--- a/db/migrate/20250918060352_add_email_to_orders.rb
+++ b/db/migrate/20250918060352_add_email_to_orders.rb
@@ -1,0 +1,5 @@
+class AddEmailToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :email, :string, null: false, comment: 'メールアドレス'
+  end
+end

--- a/db/migrate/20250918060434_add_telephone_to_orders.rb
+++ b/db/migrate/20250918060434_add_telephone_to_orders.rb
@@ -1,0 +1,5 @@
+class AddTelephoneToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :telephone, :string, null: false, comment: '電話番号'
+  end
+end

--- a/db/migrate/20250918060524_add_delivery_address_to_orders.rb
+++ b/db/migrate/20250918060524_add_delivery_address_to_orders.rb
@@ -1,0 +1,5 @@
+class AddDeliveryAddressToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :delivery_address, :string, null: false, comment: 'お届け先住所'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_16_084125) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_18_060524) do
   create_table "orders", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "email", null: false
+    t.string "telephone", null: false
+    t.string "delivery_address", null: false
   end
 
 end


### PR DESCRIPTION
## 概要

1. 入力画面にメールアドレス・電話番号・お届け先住所の項目を追加
2. 確認画面にメールアドレス・電話番号・お届け先住所の項目を追加
3. データベースのordersテーブルにmail、telephone、delivery_addressのカラムを追加

## 実装詳細

- 追加ファイル
db/migrate/20250918060352_add_email_to_orders.rb
db/migrate/20250918060434_add_telephone_to_orders.rb
db/migrate/20250918060524_add_delivery_address_to_orders.rb

- 修正・変更ファイル
app/controllers/orders_controller.rb
app/views/orders/complete.html.erb
app/views/orders/confirm.html.erb
app/views/orders/new.html.erb
config/locales/ja.yml

- 実装画面・差分（ローカル）
・注文フォーム
<img width="1917" height="1918" alt="Group 15" src="https://github.com/user-attachments/assets/d9728a94-2be1-44fb-8355-c309b016e17a" />
　
・確認画面
<img width="1917" height="1962" alt="Group 16" src="https://github.com/user-attachments/assets/fce537e5-e8ff-4631-ab6b-955499e82080" />



