### PR TITLE
外部キーの追加とトランザクションの設定

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,8 @@
 require 'nkf'
 
 class Order < ApplicationRecord
+  belongs_to :payment_method
+
   validates :name, presence: true, length: { maximum:40 }
   validates :email, presence: true, length: { maximum:100 }, email_format: true
   validates :telephone, presence: true, length: { maximum:11 }, numericality: { only_integer: true }

--- a/app/models/payment_method.rb
+++ b/app/models/payment_method.rb
@@ -1,0 +1,2 @@
+class PaymentMethod < ApplicationRecord
+end

--- a/db/migrate/20251003213549_create_payment_methods.rb
+++ b/db/migrate/20251003213549_create_payment_methods.rb
@@ -1,0 +1,9 @@
+class CreatePaymentMethods < ActiveRecord::Migration[7.0]
+  def change
+    create_table :payment_methods, comment: '支払い方法' do |t|
+      t.string :name, comment: '名称'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251003213654_add_reference_payment_method_id_to_orders.rb
+++ b/db/migrate/20251003213654_add_reference_payment_method_id_to_orders.rb
@@ -1,0 +1,5 @@
+class AddReferencePaymentMethodIdToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :orders, :payment_method, foreign_key: { on_update: :restrict, on_delete: :restrict }, comment: '支払い方法'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_09_18_060524) do
+ActiveRecord::Schema[7.0].define(version: 2025_10_03_213654) do
   create_table "orders", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -18,6 +18,15 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_18_060524) do
     t.string "email", null: false
     t.string "telephone", null: false
     t.string "delivery_address", null: false
+    t.integer "payment_method_id"
+    t.index ["payment_method_id"], name: "index_orders_on_payment_method_id"
   end
 
+  create_table "payment_methods", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "orders", "payment_methods", on_update: :restrict, on_delete: :restrict
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,13 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+ApplicationRecord.transaction do
+  PaymentMethod.delete_all
+
+  PaymentMethod.create(id: 1, name: 'クレジットカード')
+  PaymentMethod.create(id: 2, name: '銀行振込')
+  PaymentMethod.create(id: 3, name: '代引き')
+  PaymentMethod.create(id: 4, name: 'コンビニ払い')
+  PaymentMethod.create(id: 5, name: '郵便為替')
+end


### PR DESCRIPTION
## 概要

1. 新たにdbに今回は外部キーとしてseeds.rb経由でPayment_Methodテーブルを追加する
2. エラーが発生することを考慮してトランザクションの設定を追加

### 課題

1. Payment_Methodテーブルの追加
2. クレジットカード、銀行振込、代引き、コンビニ払いのカラムを敢えて先に追加
3. 郵便為替のカラムを後から追加（エラーが起こらないようにトランザクションの設定をする）

## 実装詳細

- 追加ファイル
app/models/payment_method.rb

- 修正・変更ファイル
app/models/order.rb
db/migrate/20251003213549_create_payment_methods.rb
db/migrate/20251003213654_add_reference_payment_method_id_to_orders.rb
db/schema.rb
db/seeds.rb

- 実装画面・差分（ローカル）
<img width="414" height="153" alt="スクリーンショット 2025-10-04 072223" src="https://github.com/user-attachments/assets/9639aab4-1e41-4b1f-bd6c-c1afdd520a18" />

