### PR TITLE
テキストエリアの追加とRspecの追加

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,6 +36,7 @@ class OrdersController < ApplicationController
               :email,
               :telephone,
               :delivery_address,
-              :payment_method_id)
+              :payment_method_id,
+              :other_comment)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,9 +7,10 @@ class Order < ApplicationRecord
   validates :email, presence: true, length: { maximum:100 }, email_format: true
   validates :telephone, presence: true, length: { maximum:11 }, numericality: { only_integer: true }
   validates :delivery_address, presence: true, length: { maximum:100 }
+  validates :other_comment, length: { maximum: 1_000 }
 
-  # after_initialize :format_telephone
-  # after_initialize :format_email
+  after_initialize :format_telephone
+  after_initialize :format_email
 
   private
 

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -36,6 +36,16 @@
       </div>
       <%= @order.payment_method.name %>
     </div>
+    <div class="mb-3">
+      <div class="form-label border-start border-primary border-4 ps-1">
+        <%= t('activerecord.attributes.order.other_comment') %>
+      </div>
+      <% if @order.other_comment.present? %>
+        <%= simple_format(@order.other_comment) %>
+      <% else %>
+        <span class="text-secondary">（未記入）</span>
+      <% end %>
+    </div>
   </div>
 
   <%= form_for @order, url: orders_path do |f| %>
@@ -44,6 +54,7 @@
     <%= f.hidden_field :telephone %>
     <%= f.hidden_field :delivery_address %>
     <%= f.hidden_field :payment_method_id %>
+    <%= f.hidden_field :other_comment %>
     <div class="d-grid col-md-6 mx-auto mb-3">
       <%= f.button 'OK', class: 'btn btn-lg btn-primary' %>
     </div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -29,6 +29,12 @@
         <%= f.select :payment_method_id, PaymentMethod.selectable_methods, { include_blank: true }, class: 'form-select' %>
         <%= render partial: 'shared/error_messages', locals: { record: @order, symbol: :payment_method_id } %>
       </div>
+
+      <div class="mb-3">
+        <%= f.label :other_comment, class: 'form-label border-start border-primary border-4 ps-1' %>
+        <%= f.text_area :other_comment, size: '60x6', placeholder: 'その他、ご要望がありましたらご入力ください。', class: 'form-control' %>
+        <%= render partial: 'shared/error_messages', locals: { record: @order, symbol: :other_comment } %>
+      </div>
     </div>
 
     <div class="d-grid col-md-6 mx-auto">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,3 +7,4 @@ ja:
         telephone: 電話番号
         delivery_address: お届け先住所
         payment_method_id: 支払い方法
+        other_comment: その他・ご要望

--- a/db/migrate/20251006225041_add_other_comment_to_orders.rb
+++ b/db/migrate/20251006225041_add_other_comment_to_orders.rb
@@ -1,0 +1,5 @@
+class AddOtherCommentToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :orders, :other_comment, :string, null: false, default: '', limit: 1000, comment: 'その他・ご要望'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_10_03_213654) do
+ActiveRecord::Schema[7.0].define(version: 2025_10_06_225041) do
   create_table "orders", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_10_03_213654) do
     t.string "telephone", null: false
     t.string "delivery_address", null: false
     t.integer "payment_method_id"
+    t.string "other_comment", limit: 1000, default: "", null: false
     t.index ["payment_method_id"], name: "index_orders_on_payment_method_id"
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,19 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
+  before do
+    allow_any_instance_of(Order).to receive(:format_telephone)
+    allow_any_instance_of(Order).to receive(:format_email)
+  end
   describe '#valid?' do
     let(:name) { 'サンプルマン' }
     let(:email) { 'test@example.com' }
     let(:telephone) { '0312345678' }
     let(:delivery_address) { '東京都葛飾区亀有公園前' }
     let(:payment_method_id) { 1 }
+    let(:other_comment) { 'テストコメントです' }
     let(:params) do
       {
         name:,
         email:,
         telephone:,
         delivery_address:,
-        payment_method_id:
+        payment_method_id:,
+        other_comment:,
       }
     end
 
@@ -76,6 +82,16 @@ RSpec.describe Order, type: :model do
     end
     context '支払い方法が未入力の場合' do
       let(:payment_method_id) { nil }
+
+      it {is_expected.to eq false}
+    end
+    context 'その他・ご要望が空白の場合' do
+      let(:other_comment) { '' }
+
+      it {is_expected.to eq true}
+    end
+    context 'その他・ご要望が空白の場合' do
+      let(:other_comment) { 'あ' * 1_001 }
 
       it {is_expected.to eq false}
     end

--- a/spec/system/orders_spec.rb
+++ b/spec/system/orders_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "注文フォーム", type: :system do
   let(:email) { 'test@example.com' }
   let(:telephone) { '0312345678' }
   let(:delivery_address) { '東京都葛飾区亀有公園前' }
+  let(:other_comment) { 'テストコメントです' }
 
   it '商品を注文できること' do
     visit new_order_path
@@ -16,6 +17,7 @@ RSpec.describe "注文フォーム", type: :system do
     fill_in '電話番号', with: telephone
     fill_in 'お届け先住所', with: delivery_address
     select '銀行振込', from: '支払い方法'
+    fill_in 'その他・ご要望', with: other_comment
 
     click_on '確認画面へ'
 
@@ -36,6 +38,7 @@ RSpec.describe "注文フォーム", type: :system do
     expect(order.telephone).to eq telephone
     expect(order.delivery_address).to eq delivery_address
     expect(order.payment_method_id).to eq 2
+    expect(order.other_comment).to eq other_comment
   end
 
   context '入力情報に不備がある場合' do
@@ -48,6 +51,7 @@ RSpec.describe "注文フォーム", type: :system do
       fill_in '電話番号', with: '090123456789'
       fill_in 'お届け先住所', with: delivery_address
       select '銀行振込', from: '支払い方法'
+      fill_in 'その他・ご要望', with: other_comment
 
       click_on '確認画面へ'
 
@@ -66,6 +70,7 @@ RSpec.describe "注文フォーム", type: :system do
       fill_in '電話番号', with: telephone
       fill_in 'お届け先住所', with: delivery_address
       select '銀行振込', from: '支払い方法'
+      fill_in 'その他・ご要望', with: other_comment
 
       click_on '確認画面へ'
 
@@ -82,6 +87,7 @@ RSpec.describe "注文フォーム", type: :system do
       expect(page).to have_field '電話番号', with: telephone
       expect(page).to have_field 'お届け先住所', with: delivery_address
       expect(page).to have_select '支払い方法', selected: '銀行振込'
+      expect(page).to have_field 'その他・ご要望', with: other_comment
 
       click_on '確認画面へ'
 
@@ -102,6 +108,7 @@ RSpec.describe "注文フォーム", type: :system do
       expect(order.telephone).to eq telephone
       expect(order.delivery_address).to eq delivery_address
       expect(order.payment_method_id).to eq 2
+      expect(order.other_comment).to eq other_comment
     end
   end  
 end


### PR DESCRIPTION
## 概要

1. 入力画面にその他・ご要望の入力項目を追加
3. その他・ご要望のテスト項目を追加

## 実装詳細

- 追加ファイル
新しく追加したファイルは無し

- 修正・変更ファイル
app/controllers/orders_controller.rb
app/models/order.rb
app/views/orders/confirm.html.erb
app/views/orders/new.html.erb
config/locales/ja.yml
db/migrate/20251006225041_add_other_comment_to_orders.rb
spec/models/order_spec.rb
spec/system/orders_spec.rb

- 実装画面・差分（ローカル）
### 入力画面
<img width="1917" height="1239" alt="FireShot Capture 009 - 注文フォーム -  localhost" src="https://github.com/user-attachments/assets/5018ce06-18c6-4152-aa0d-35501e60aeaf" />
 
### 確認画面
<img width="1917" height="1239" alt="FireShot Capture 011 - 注文フォーム -  localhost" src="https://github.com/user-attachments/assets/fc88b53f-cd30-4017-875a-29bc798f5af7" />
